### PR TITLE
provide both perspectives in stable_matchings dictionary

### DIFF
--- a/src/algmatch/stableMatchings/hospitalResidentsProblem/hrAbstract.py
+++ b/src/algmatch/stableMatchings/hospitalResidentsProblem/hrAbstract.py
@@ -23,7 +23,10 @@ class HRAbstract:
         self.hospitals = self._reader.hospitals
 
         self.M = {} # provisional matching
-        self.stable_matching = {}
+        self.stable_matching = {
+            "resident_sided": {resident: "" for resident in self.residents},
+            "hospital_sided": {hospital: [] for hospital in self.hospitals}
+        }
         self.blocking_pair = False
 
     def _blocking_pair_condition(self, resident, hospital):
@@ -75,11 +78,9 @@ class HRAbstract:
         self._check_stability()
 
         for resident in self.residents:
-            if self.M[resident]["assigned"] is not None:
-                self.stable_matching[resident] = self.M[resident]["assigned"]
-            else:
-                self.stable_matching[resident] = ""
+            if hospital := self.M[resident]["assigned"] is not None:
+                self.stable_matching["resident_sided"][resident] = hospital
+                self.stable_matching["hospital_sided"][hospital].append(resident)
 
-        if not self.blocking_pair:
-            return f"stable matching: {self.stable_matching}"
+        if not self.blocking_pair: return f"stable matching: {self.stable_matching}"
         else: return f"unstable matching: {self.stable_matching}"

--- a/src/algmatch/stableMatchings/stableMarriageProblem/smAbstract.py
+++ b/src/algmatch/stableMatchings/stableMarriageProblem/smAbstract.py
@@ -23,7 +23,10 @@ class SMAbstract:
         self.women = self._reader.women
 
         self.M = {} # provisional matching
-        self.stable_matching = {}
+        self.stable_matching = {
+            "man_sided": {m: "" for m in self.men},
+            "woman_sided": {w: "" for w in self.women}
+        }
         self.blocking_pair = False
 
     # =======================================================================    
@@ -65,11 +68,9 @@ class SMAbstract:
         self._check_stability()
 
         for man in self.men:
-            if self.M[man]["assigned"] is not None:
-                self.stable_matching[man] = self.M[man]["assigned"]
-            else:
-                self.stable_matching[man] = ""
+            if woman := self.M[man]["assigned"] is not None:
+                self.stable_matching["man_sided"][man] = woman
+                self.stable_matching["woman_sided"][woman] = man
 
-        if not self.blocking_pair:
-            return f"stable matching: {self.stable_matching}"
+        if not self.blocking_pair: return f"stable matching: {self.stable_matching}"
         else: return f"unstable matching: {self.stable_matching}"

--- a/src/algmatch/stableMatchings/studentProjectAllocation/spaAbstract.py
+++ b/src/algmatch/stableMatchings/studentProjectAllocation/spaAbstract.py
@@ -24,7 +24,10 @@ class SPAAbstract:
         self.lecturers = self._reader.lecturers
 
         self.M = {} # provisional matching
-        self.stable_matching = {}
+        self.stable_matching = {
+            "student_sided": {student: "" for student in self.students},
+            "lecturer_sided": {lecturer: [] for lecturer in self.lecturers}
+        }
         self.blocking_pair = False
 
 
@@ -112,7 +115,10 @@ class SPAAbstract:
         self._check_stability()
 
         for student in self.students:
-            self.stable_matching[student] = self.M[student]["assigned"] if self.M[student]["assigned"] is not None else ""
+            if project := self.M[student]["assigned"] is not None:
+                lecturer = self.projects[project]["lecturer"]
+                self.stable_matching["student_sided"][student] = project
+                self.stable_matching["lecturer_sided"][lecturer].append(student)
 
         if not self.blocking_pair: return f"stable matching: {self.stable_matching}"
         else: return f"unstable matching: {self.stable_matching}"


### PR DESCRIPTION
made it so that each stable matching abstract file creates an "empty" stable matchings dictionary
then in run function it fills it in
the stable matchings dictionary is now first indexed by `X_sided`, e.g. `stable_matchings["lecturer_sided"]` and has the same structure at this level